### PR TITLE
Add simple React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 *.pyc
 backend/data/horoscopes/
+# frontend
+frontend/node_modules/

--- a/README.md
+++ b/README.md
@@ -16,3 +16,13 @@ Backend project providing roasted horoscope data.
    ```bash
    uvicorn backend.api.main:app --reload
    ```
+
+## Frontend
+
+A minimal React-based frontend is available in the `frontend/` directory. It uses CDN versions of React so no build step is required. Run a simple HTTP server to view it locally:
+
+```bash
+python -m http.server 3000 -d frontend
+```
+
+Open `http://localhost:3000` in your browser while the backend API is running on `http://localhost:8000`.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HoroscHope</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <div id="root"></div>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,48 @@
+const { useState } = React;
+
+function App() {
+  const [sign, setSign] = useState("");
+  const [roast, setRoast] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const fetchRoast = async () => {
+    if (!sign) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`http://localhost:8000/horoscope/${sign}/daily`);
+      if (!res.ok) throw new Error("Request failed");
+      const data = await res.json();
+      setRoast(data.roast);
+    } catch (err) {
+      setRoast("Error fetching horoscope");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return React.createElement(
+    "div",
+    { className: "container" },
+    React.createElement("h1", null, "HoroscHope"),
+    React.createElement(
+      "div",
+      { className: "form" },
+      React.createElement("input", {
+        value: sign,
+        onChange: (e) => setSign(e.target.value),
+        placeholder: "Enter sign",
+      }),
+      React.createElement(
+        "button",
+        { onClick: fetchRoast, disabled: loading },
+        "Get Roast"
+      )
+    ),
+    loading && React.createElement("p", null, "Loading..."),
+    roast && React.createElement("p", { className: "roast" }, roast)
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  React.createElement(App)
+);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,36 @@
+body {
+    font-family: Arial, sans-serif;
+    background: #f9f9f9;
+    margin: 0;
+    padding: 20px;
+}
+
+.container {
+    max-width: 600px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.form {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-bottom: 20px;
+}
+
+input {
+    padding: 8px;
+    font-size: 1em;
+}
+
+button {
+    padding: 8px 16px;
+    font-size: 1em;
+    cursor: pointer;
+}
+
+.roast {
+    background: #fff3cd;
+    padding: 10px;
+    border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- add CDN-based React UI under `frontend/`
- update `.gitignore` for frontend node modules
- document how to run the frontend in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685660c598b8832590d0661d520d4b1f